### PR TITLE
[BK] - Implement User login endpoint and user auth

### DIFF
--- a/backend/apps/shipments/views.py
+++ b/backend/apps/shipments/views.py
@@ -17,6 +17,7 @@ from .serializer import(
     CreateRescheduleSerializer
 )
 from django.shortcuts import get_object_or_404
+from rest_framework.permissions import IsAuthenticated
 
 from .services import(
     create_reschedule
@@ -25,6 +26,7 @@ from .services import(
 class ShipmentViewSet(ReadOnlyModelViewSet):
     queryset = Shipment.objects.all()
     serializer_class = ShipmentSerializer
+    permission_classes = [IsAuthenticated]
     tags = ['Shipment']
     
     def get_serializer_class(self):
@@ -36,12 +38,14 @@ class ShipmentViewSet(ReadOnlyModelViewSet):
 class ShipmentUpdateViewSet(ReadOnlyModelViewSet):
     queryset = ShipmentUpdate.objects.all()
     serializer_class = ShipmentUpdateSerializer
+    permission_classes = [IsAuthenticated]
     tags = ['ShipmentUpdate']
     
     
 class RescheduleViewSet(ModelViewSet):
     queryset = Reschedule.objects.all()
     serializer_class = RescheduleSerializer
+    permission_classes = [IsAuthenticated]
     tags = ['Reschedule']
     
     def get_serializer_class(self):

--- a/backend/apps/users/serializers.py
+++ b/backend/apps/users/serializers.py
@@ -1,0 +1,11 @@
+from rest_framework import serializers
+from .models import User
+
+class LoginSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    password = serializers.CharField(write_only=True)
+    
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        exclude = ['password']

--- a/backend/apps/users/urls.py
+++ b/backend/apps/users/urls.py
@@ -1,0 +1,7 @@
+from .views import UserViewSet
+from rest_framework_nested import routers
+
+router = routers.SimpleRouter()
+router.register('users', UserViewSet, 'user')
+
+urlpatterns = router.urls

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -1,3 +1,42 @@
-from django.shortcuts import render
+from django.contrib.auth import authenticate, login
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework.viewsets import ReadOnlyModelViewSet
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework import status
+from .serializers import LoginSerializer, UserSerializer
+from .models import User
 
-# Create your views here.
+class UserViewSet(ReadOnlyModelViewSet):
+    """
+    A viewset for viewing and editing user instances.
+    Provides a login action to authenticate users and return JWT tokens.
+    """
+    tags = ['User']
+    serializer_class = UserSerializer
+    queryset = User.objects.all()
+
+    def get_serializer_class(self):
+        if self.action == 'login':
+            return LoginSerializer
+        return UserSerializer
+
+    @action(detail=False, methods=['post'], url_path='login')
+    def login(self, request):
+        serializer = self.get_serializer(data=request.data)
+        if serializer.is_valid():
+            email = serializer.validated_data['email']
+            password = serializer.validated_data['password']
+            user = authenticate(request, username=email, password=password)
+            if user is not None:
+                login(request, user)
+                refresh = RefreshToken.for_user(user)
+                return Response({
+                    'refresh': str(refresh),
+                    'access': str(refresh.access_token),
+                    'message': 'Login successful'
+                }, status=status.HTTP_200_OK)
+            return Response({'message': 'Invalid credentials'}, status=status.HTTP_401_UNAUTHORIZED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/backend/project/urls.py
+++ b/backend/project/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
 
 apps=[
     'apps.shipments',
+    'apps.users',
 ]
 
 for app in apps:


### PR DESCRIPTION
## Ticket
[JIRA-24](https://sl-urban.atlassian.net/browse/SDP-24)

This pull request introduces several significant changes to the backend of the application, focusing on enhancing security and adding user authentication features. The most important changes include the addition of authentication requirements for shipment-related views, the creation of serializers for user login and user data, the setup of URL routing for user-related endpoints, and the implementation of a `UserViewSet` to handle user login and JWT token generation.

Improvements to security:

* [`backend/apps/shipments/views.py`](diffhunk://#diff-c87af4fe68038c17a3bbc3a11ea6050d082fa30f2f71123ce4992307c7884390R20): Added `IsAuthenticated` permission class to `ShipmentViewSet`, `ShipmentUpdateViewSet`, and `RescheduleViewSet` to ensure that only authenticated users can access these views. [[1]](diffhunk://#diff-c87af4fe68038c17a3bbc3a11ea6050d082fa30f2f71123ce4992307c7884390R20) [[2]](diffhunk://#diff-c87af4fe68038c17a3bbc3a11ea6050d082fa30f2f71123ce4992307c7884390R29) [[3]](diffhunk://#diff-c87af4fe68038c17a3bbc3a11ea6050d082fa30f2f71123ce4992307c7884390R41-R48)

User authentication features:

* [`backend/apps/users/serializers.py`](diffhunk://#diff-fe5b6217e73c4bcebd16fe99256e509afcccec57e2fef30cba549dc0ade6ddfbR1-R11): Created `LoginSerializer` for handling user login data and `UserSerializer` for serializing user data, excluding passwords.
* [`backend/apps/users/urls.py`](diffhunk://#diff-dacee5c49cfedbd3e13ddea2c9bfbc664d20e0f7b352f550a47b2b5cfa3fc799R1-R7): Set up URL routing for user-related endpoints using `rest_framework_nested` routers.
* [`backend/apps/users/views.py`](diffhunk://#diff-16c9097f8e004715a8da7c811a72794ae4c6346e4c446a8d63463f5d010c778aL1-R42): Implemented `UserViewSet` with a login action to authenticate users and return JWT tokens.
* [`backend/project/urls.py`](diffhunk://#diff-29db1f331bc9b42ed96cb792eb35a0b54fbc4d32baf813774f688326339df1d1R37): Added `apps.users` to the project URLs to include user-related routes.