### PR TITLE
Get Shipment by tracking ID

### DIFF
--- a/backend/apps/shipments/views.py
+++ b/backend/apps/shipments/views.py
@@ -2,6 +2,7 @@ from rest_framework.viewsets import ReadOnlyModelViewSet,ModelViewSet,ViewSet
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.exceptions import APIException
+from rest_framework.decorators import action
 
 from .models import(
     Shipment,
@@ -42,6 +43,13 @@ class ShipmentViewSet(ReadOnlyModelViewSet):
     
     def get_queryset(self):
         return Shipment.objects.filter(customer=self.request.user).order_by('-created_at')
+    
+    @action(detail=False, methods=['get'], url_path='track/(?P<tracking_id>[^/.]+)')
+    def get_shipment_by_tracking_id(self,request, tracking_id):
+        response = Shipment.objects.filter(tracking_id=tracking_id).first()
+        if not response:
+            raise APIException("Shipment not found")
+        return Response(ShipmentDetailSerializer(response).data, status=status.HTTP_200_OK)
     
 class ShipmentUpdateViewSet(ReadOnlyModelViewSet):
     queryset = ShipmentUpdate.objects.all()

--- a/client/src/components/TrackingSearch.tsx
+++ b/client/src/components/TrackingSearch.tsx
@@ -2,16 +2,36 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useNavigate } from "react-router-dom";
+import { getShipmentByTrackingId } from "@/services/shipmentService";
+import { toast } from "@/components/ui/use-toast";
 
 export const TrackingSearch = () => {
   const [trackingId, setTrackingId] = useState("");
   const navigate = useNavigate();
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (trackingId) {
-      navigate(`/shipment/${trackingId}`);
+      try {
+        const shipment = await getShipmentByTrackingId(trackingId);
+        console.log("shipment", shipment);
+        if (shipment) {
+          navigate(`/shipment/${shipment.id}`);
+        } else {
+          showErrorToast("Tracking ID is incorrect");
+        }
+      } catch (error) {
+        console.error("Failed to fetch shipment:", error);
+        showErrorToast("Tracking ID is incorrect");
+      }
     }
+  };
+
+  const showErrorToast = (message: string) => {
+    toast({
+      title: "Tracking ID Not Found",
+      description: "Please check the tracking ID and try again",
+    });
   };
 
   return (

--- a/client/src/services/shipmentService.ts
+++ b/client/src/services/shipmentService.ts
@@ -56,3 +56,25 @@ export const connectShipmentWebSocket = (trackingId: string, onMessage: (update:
     };
     return ws;
 };
+
+export const getShipmentByTrackingId = async (trackingId: string) => {
+    const accessToken = localStorage.getItem('accessToken');
+    if (!accessToken) {
+        throw new Error('No access token found');
+    }
+
+    const response = await fetch(`http://localhost:8000/api/shipments/track/${trackingId}`, {
+        method: 'GET',
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json'
+        }
+    });
+
+    if (!response.ok) {
+        throw new Error('Failed to fetch shipment');
+    }
+
+    const data = await response.json();
+    return data;
+}


### PR DESCRIPTION
## Ticket
[JIRA-31](https://sl-urban.atlassian.net/browse/SDP-31)

This pull request includes significant changes to both the backend and frontend of the shipment tracking feature. The main updates involve adding a new endpoint to fetch shipment details by tracking ID and updating the frontend to handle the new endpoint and show appropriate error messages.

Backend changes:

* [`backend/apps/shipments/views.py`](diffhunk://#diff-c87af4fe68038c17a3bbc3a11ea6050d082fa30f2f71123ce4992307c7884390R5): Added a new action `get_shipment_by_tracking_id` to fetch shipment details by tracking ID. This action returns the shipment details if found, otherwise raises an `APIException`. [[1]](diffhunk://#diff-c87af4fe68038c17a3bbc3a11ea6050d082fa30f2f71123ce4992307c7884390R5) [[2]](diffhunk://#diff-c87af4fe68038c17a3bbc3a11ea6050d082fa30f2f71123ce4992307c7884390R47-R53)

Frontend changes:

* [`client/src/components/TrackingSearch.tsx`](diffhunk://#diff-33d5d49ba093b83791a124f8b439ecf67d292aa67907a2286f7de32618c42875R5-R34): Updated the `handleSubmit` function to use the new `getShipmentByTrackingId` service. Added error handling to show a toast notification if the tracking ID is incorrect.
* [`client/src/services/shipmentService.ts`](diffhunk://#diff-fc150f6c3326029d4fc8668e97175b3344ed07b2d34ddcff06363b6561983001R59-R80): Added a new function `getShipmentByTrackingId` to fetch shipment details from the backend using the tracking ID.