### PR TITLE
[UI] - Wire up patch API call for notification preferences

### DIFF
--- a/backend/apps/shipments/views.py
+++ b/backend/apps/shipments/views.py
@@ -112,7 +112,7 @@ class NotificationViewSet(ModelViewSet):
     def partial_update(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
-        notification_instance = get_object_or_404(Notification, id=kwargs.get('shipment_pk'))
+        notification_instance = get_object_or_404(Notification, shipment=kwargs.get('shipment_pk'),id=kwargs.get('pk'))
         if notification_instance.shipment.customer != request.user:
             raise APIException("You are not authorized to update this notification method")
         result = update_notification_methods(notification_instance, serializer.validated_data)

--- a/client/src/pages/ShipmentDetail.tsx
+++ b/client/src/pages/ShipmentDetail.tsx
@@ -6,7 +6,7 @@ import { Separator } from "@/components/ui/separator";
 import { toast } from "@/hooks/use-toast";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
-import { getShipment, connectShipmentWebSocket } from "@/services/shipmentService"; // Import the getShipment and connectShipmentWebSocket functions
+import { getShipment, connectShipmentWebSocket, updateNotificationSettings } from "@/services/shipmentService"; // Import the getShipment and connectShipmentWebSocket functions
 
 const ShipmentDetail = () => {
   const { id } = useParams();
@@ -16,6 +16,7 @@ const ShipmentDetail = () => {
     send_sms: false,
     send_push_notification: false,
   });
+  const [hasChanges, setHasChanges] = useState(false);
   const [isWebSocketActive, setIsWebSocketActive] = useState(false);
   const ws = useRef<WebSocket | null>(null);
 
@@ -52,10 +53,24 @@ const ShipmentDetail = () => {
 
   const handleNotificationChange = (type: "send_email" | "send_sms" | "send_push_notification", checked: boolean) => {
     setNotifications((prev) => ({ ...prev, [type]: checked }));
-    toast({
-      title: "Notification preferences updated",
-      description: `${type.replace('_', ' ')} notifications have been ${checked ? 'enabled' : 'disabled'}`,
-    });
+    setHasChanges(true);
+  };
+
+  const handleSaveChanges = async () => {
+    try {
+      await updateNotificationSettings(id, shipmentDetails.notifications.id, notifications); // Assuming notificationId is available
+      setHasChanges(false);
+      toast({
+        title: "Notification preferences updated",
+        description: "Your notification preferences have been saved.",
+      });
+    } catch (error) {
+      console.error("Failed to update notification settings:", error);
+      toast({
+        title: "Error",
+        description: "Failed to update notification settings.",
+      });
+    }
   };
 
   if (!shipmentDetails) {
@@ -123,6 +138,14 @@ const ShipmentDetail = () => {
                   <Label htmlFor="push-notifications">Push Notifications</Label>
                 </div>
               </div>
+              {hasChanges && (
+                <button
+                  onClick={handleSaveChanges}
+                  className="mt-4 px-4 py-2 bg-blue-600 text-white rounded-md"
+                >
+                  Save Changes
+                </button>
+              )}
             </div>
 
             <Separator />

--- a/client/src/services/shipmentService.ts
+++ b/client/src/services/shipmentService.ts
@@ -78,3 +78,23 @@ export const getShipmentByTrackingId = async (trackingId: string) => {
     const data = await response.json();
     return data;
 }
+
+export const updateNotificationSettings = async (shipmentId: string, notificationId: string, settings: any) => {
+    const accessToken = localStorage.getItem('accessToken');
+    if (!accessToken) {
+        throw new Error('No access token found');
+    }
+
+    const response = await fetch(`http://localhost:8000/api/shipments/${shipmentId}/notifications/${notificationId}/`, {
+        method: 'PATCH',
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(settings)
+    });
+
+    if (!response.ok) {
+        throw new Error('Failed to update notification settings');
+    }
+}


### PR DESCRIPTION
## Ticket
[JIRA-34](https://sl-urban.atlassian.net/browse/SDP-34)

This pull request includes several changes to both the backend and frontend to improve the handling and updating of notification settings for shipments. The most important changes include updates to the backend `partial_update` method, the addition of new functions and state management in the frontend, and the integration of a new API endpoint for updating notification settings.

### Backend Changes:
* [`backend/apps/shipments/views.py`](diffhunk://#diff-c87af4fe68038c17a3bbc3a11ea6050d082fa30f2f71123ce4992307c7884390L115-R115): Modified the `partial_update` method to include an additional filter by `id` when retrieving the `Notification` instance. This ensures that the correct notification is updated.

### Frontend Changes:
* `client/src/pages/ShipmentDetail.tsx`: 
  * Imported the `updateNotificationSettings` function from `shipmentService`.
  * Added a `hasChanges` state to track if notification settings have been modified.
  * Updated the `handleNotificationChange` function to set `hasChanges` to true when changes are made.
  * Introduced the `handleSaveChanges` function to save updated notification settings and provide user feedback.
  * Added a "Save Changes" button that appears when there are unsaved changes.

* [`client/src/services/shipmentService.ts`](diffhunk://#diff-fc150f6c3326029d4fc8668e97175b3344ed07b2d34ddcff06363b6561983001R81-R100): Added the `updateNotificationSettings` function to handle the PATCH request for updating notification settings via the API.